### PR TITLE
Whitelisting implemented

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,8 +52,9 @@ Since this script needs write-access to the hostfile defined in $ADNAME, it will
 - [x] Work with functions
 - [x] Implement a visual feedback with `--generate`
 - [x] Clean unnecessary code, make it pretty
-- [x] Put options in /etc/{config}
+- [x] Put options in /etc/machtsinn/machtsinn.conf
 - [x] Implement logging
+- [x] Implement whitelisting (read /etc/machtsinn/README.txt for further information)
 - [ ] Perform a pre-running check
 
 Send me your suggestions for new features!

--- a/etc/machtsinn/README.txt
+++ b/etc/machtsinn/README.txt
@@ -1,0 +1,23 @@
+##################################
+## Script-Name:     macht-sinn  ##
+## Type:            Script      ##
+## Creator:         Crosser     ##
+## License:         GPLv3       ##
+##################################
+
+!! Please do read machtsinn.conf carefully before editing or using this script !!
+
+###
+## Whitelist usage
+###
+
+In /etc/machtsinn/whitelist.conf you can specifie one domain per line, which should never get blocked.
+Please use this feature with care and do run some tests before putting it in a productive environment.
+
+## Example entry in /etc/machtsinn/whitelist.conf
+
+duckduckgo.com
+
+This entry makes sure, duckduckgo.com and(!) www.duckduckgo.com never gets into your final blacklist.
+All domains containig duckduckgo.com will also get unblocked at this point, resulting in fishing.duckduckgo.com.spammer.org
+also getting removed from the final blacklist. Hopefully I can fix this in the near future.

--- a/etc/machtsinn/whitelist.conf
+++ b/etc/machtsinn/whitelist.conf
@@ -1,8 +1,0 @@
-#!/bin/bash
-
-##################################
-## Script-Name: 	macht-sinn	##
-## Type:			Config		##
-## Creator:			Crosser		##
-## License:	        GPLv3		##
-##################################


### PR DESCRIPTION
You can now whitelist domains in /etc/machtsinn/whitelist.conf with entrys like "duckduckgo.com".
This helps with sites necessary for a productive environment. Please do read /etc/machtsinn/README.txt.
